### PR TITLE
入门教程的文件路径需要更新

### DIFF
--- a/docs/CodePlugins/Exsample.md
+++ b/docs/CodePlugins/Exsample.md
@@ -2,7 +2,7 @@
 
 ::: tip
 
-该文件位于`gsuid_core/plugins/gs_test.py`
+该文件位于`gsuid_core/buildin_plugins/gs_test.py`
 
 :::
 


### PR DESCRIPTION
对照官网的地址找不到，然后搜源码发现移动到这个文件夹了