### PR TITLE
✨ 新增异环插件 NTEUID

### DIFF
--- a/docs/public/plugin_list.json
+++ b/docs/public/plugin_list.json
@@ -366,6 +366,22 @@
         "洛克王国",
         "洛克王国：世界"
       ]
+    },
+    "NTEUID": {
+      "link": "https://github.com/tyql688/NTEUID",
+      "avatar": "https://github.com/tyql688.png",
+      "cover": "https://raw.githubusercontent.com/tyql688/NTEUID/main/ICON.png",
+      "branch": "main",
+      "type": "tip",
+      "content": "普通",
+      "info": "全功能异环插件",
+      "installMsg": "",
+      "alias": [
+        "nte",
+        "nteuid",
+        "yh",
+        "异环"
+      ]
     }
   },
   "fun_plugins": [
@@ -395,7 +411,8 @@
     "LOLegendsUID",
     "BlueArchiveUID",
     "RH_ComfyUI",
-    "RocomUID"
+    "RocomUID",
+    "NTEUID"
   ],
   "extra": {
     


### PR DESCRIPTION
## Summary
- 在 `docs/public/plugin_list.json` 的 `plugins` 中新增 `NTEUID`（仓库：https://github.com/tyql688/NTEUID）
- 同步加入 `tool_plugins` 分类，使其在工具插件列表中展示
- 别名：`nte`、`nteuid`、`yh`、`异环`

## Test plan
- [ ] 本地 `bun run dev` 启动文档站，确认插件列表新增条目并能正常加载封面/头像
- [ ] 在工具插件分类中能看到 NTEUID