### PR TITLE
新增 gs_sign_calendar 签到日历插件

### DIFF
--- a/docs/public/plugin_list.json
+++ b/docs/public/plugin_list.json
@@ -1,6 +1,6 @@
 {
   "plugins": {
-	"core_plugin_memes": {
+    "core_plugin_memes": {
       "link": "https://github.com/Loping151/core_plugin_memes",
       "avatar": "https://github.com/Loping151",
       "cover": "https://pic1.imgdb.cn/item/69a110b7d9fa54ce3f18b9fe.png",
@@ -203,8 +203,7 @@
       "content": "停止维护",
       "info": "全功能鸣潮查询插件",
       "installMsg": "",
-      "alias": [
-      ]
+      "alias": []
     },
     "XutheringWavesUID": {
       "link": "https://github.com/Loping151/XutheringWavesUID",
@@ -410,6 +409,21 @@
         "pgr",
         "战双"
       ]
+    },
+    "gs_sign_calendar": {
+      "link": "https://github.com/nnlmc/gs_sign_calendar",
+      "avatar": "https://github.com/nnlmc.png",
+      "cover": "",
+      "branch": "main",
+      "type": "tip",
+      "content": "普通",
+      "info": "鸣潮签到日历插件",
+      "installMsg": "",
+      "alias": [
+        "lu",
+        "签到日历",
+        "sign"
+      ]
     }
   },
   "fun_plugins": [
@@ -444,7 +458,5 @@
     "NTEUID",
     "PGRUID"
   ],
-  "extra": {
-    
-  }
+  "extra": {}
 }


### PR DESCRIPTION
插件信息:
- 插件名称: gs_sign_calendar
- 仓库地址: https://github.com/nnlmc/gs_sign_calendar
- 功能介绍: 鸣潮签到日历插件，支持每日签到、签到日历展示、签到盲盒图片等功能
- 别名: lu, 签到日历, sign

已在本地测试运行正常，请求合入插件市场列表。