### PR TITLE
fix: 更新插件市场仓库链接为 MimoKit

### DIFF
--- a/docs/public/plugin_list.json
+++ b/docs/public/plugin_list.json
@@ -484,9 +484,9 @@
       ]
     },
     "gs_kuro_cos": {
-      "link": "https://github.com/nnlmc/gs_kuro_cos",
-      "avatar": "https://github.com/nnlmc.png",
-      "cover": "https://raw.githubusercontent.com/nnlmc/gs_kuro_cos/main/ICON.png",
+      "link": "https://github.com/MimoKit/gs_kuro_cos",
+      "avatar": "https://github.com/MimoKit.png",
+      "cover": "https://raw.githubusercontent.com/MimoKit/gs_kuro_cos/main/ICON.png",
       "branch": "main",
       "type": "tip",
       "content": "普通",
@@ -512,9 +512,9 @@
       ]
     },
     "TodayWaifu": {
-      "link": "https://github.com/nnlmc/TodayWaifu",
-      "avatar": "https://github.com/nnlmc.png",
-      "cover": "https://raw.githubusercontent.com/nnlmc/TodayWaifu/main/ICON.png",
+      "link": "https://github.com/MimoKit/TodayWaifu",
+      "avatar": "https://github.com/MimoKit.png",
+      "cover": "https://raw.githubusercontent.com/MimoKit/TodayWaifu/main/ICON.png",
       "branch": "main",
       "type": "tip",
       "content": "普通",


### PR DESCRIPTION
## 说明

根据 GitHub 用户名变更，更新插件市场中两个已合并插件条目的仓库链接、头像和封面地址：

- `gs_kuro_cos`
- `TodayWaifu`

## 变更内容

- 将 `https://github.com/nnlmc/...` 更新为 `https://github.com/MimoKit/...`
- 将头像地址更新为 `https://github.com/MimoKit.png`
- 将 raw 封面地址更新为 `https://raw.githubusercontent.com/MimoKit/...`

## 检查

- `python -m json.tool docs/public/plugin_list.json`