### PR TITLE
feat: 添加 ChisaEating 娱乐插件条目

### DIFF
--- a/docs/public/plugin_list.json
+++ b/docs/public/plugin_list.json
@@ -527,13 +527,32 @@
         "老婆",
         "jrlp"
       ]
+    },
+    "ChisaEating": {
+      "link": "https://github.com/MimoKit/ChisaEating",
+      "avatar": "https://github.com/MimoKit.png",
+      "cover": "https://raw.githubusercontent.com/MimoKit/ChisaEating/main/ICON.png",
+      "branch": "main",
+      "type": "tip",
+      "content": "普通",
+      "info": "千小妹还在吃，跨次元随机干饭与食物推荐插件",
+      "installMsg": "",
+      "alias": [
+        "ChisaEating",
+        "千小妹还在吃",
+        "干饭",
+        "吃什么",
+        "吃啥",
+        "美食"
+      ]
     }
   },
   "fun_plugins": [
     "PsyTest",
     "aemeth_ai",
     "pokemon",
-    "core_plugin_memes"
+    "core_plugin_memes",
+    "ChisaEating"
   ],
   "tool_plugins": [
     "SayuStock",


### PR DESCRIPTION
## 说明

新增 ChisaEating 插件市场条目，并加入娱乐插件分类。

插件地址：https://github.com/MimoKit/ChisaEating

## 插件简介

ChisaEating 是 GSCore 的跨次元随机干饭与食物推荐插件，支持随机推荐食物/饮品、世界特产、厨师联动、自定义食物图片与干饭人语录等功能。

## 变更内容

- 在 `plugins` 中新增 `ChisaEating` 条目
- 在 `fun_plugins` 分类中加入 `ChisaEating`
- 使用仓库内 `ICON.png` 作为封面图

## 检查

- `python -m json.tool docs/public/plugin_list.json`